### PR TITLE
Clean-up rust shell

### DIFF
--- a/shells/esp32s2-idf-rust.nix
+++ b/shells/esp32s2-idf-rust.nix
@@ -1,11 +1,9 @@
-{ pkgs ? import ../default.nix  }:
+{ pkgs ? import ../default.nix }:
 pkgs.mkShell {
   name = "esp-idf";
 
   buildInputs = with pkgs; [
     esp-idf-esp32s2
-    # esp-idf
-    # esptool
 
     # Tools required to use ESP-IDF.
     git
@@ -30,21 +28,14 @@ pkgs.mkShell {
     rust-ldproxy
     rust-cargo-espflash
 
-    # pythonEnv.python
-    # (python3.withPackages (p: with p; [pip]))
     python3
     python3Packages.pip
     python3Packages.virtualenv
-    # stdenv.cc.cc.lib
-    # zlib
-    # libxml2
   ];
   shellHook = ''
     # fixes libstdc++ issues and libgl.so issues
-    # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${pkgs.stdenv.cc.cc.lib}/lib/:${pkgs.zlib}/lib:${pkgs.pkgsi686Linux.libxml2.dev}/lib
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.libxml2 pkgs.zlib pkgs.stdenv.cc.cc.lib ]}
     export ESP_IDF_VERSION=v4.4.1
-    # export LIBCLANG_PATH=${pkgs.llvmPackages.libclang.lib}/lib
     export LIBCLANG_PATH=${pkgs.llvm-xtensa-lib}/lib
     export RUSTFLAGS="--cfg espidf_time64"
   '';


### PR DESCRIPTION
Commented out lines in `shellHook` are still parsed by Nix, meaning pkgs.pkgsi686Linux.libxml2.dev etc are still pulled into the store, despite never being actually used (and obviously not working on other platforms than Linux).